### PR TITLE
Issue #6: Updated for modern autoconf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,13 @@ aespasswd/aespasswd
 autom4te.cache/
 config.log
 config.status
+config/compile
 config/config.guess
 config/config.sub
 config/depcomp
 config/install-sh
 config/missing
+config/test-driver
 configure
 doc/Makefile
 doc/Makefile.in

--- a/I2util/Makefile.am
+++ b/I2util/Makefile.am
@@ -20,7 +20,7 @@
 
 #include $(top_srcdir)/config/Make-rules
 
-INCLUDES	=	-I$(top_builddir) -I$(top_srcdir)
+AM_CPPFLAGS	=	-I$(top_builddir) -I$(top_srcdir)
 
 MACH_SOURCES	= mach_dep.c mach_dep.h
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,9 @@
 
 #include $(top_srcdir)/config/Make-rules
 
+ACLOCAL_AMFLAGS = -I config
+AUTOMAKE_OPTIONS = foreign
+
 SUBDIRS = I2util aespasswd pfstore test doc
 
 # uncomment when automake is unbroken 1.5 doesn't work with this...

--- a/aespasswd/Makefile.am
+++ b/aespasswd/Makefile.am
@@ -18,7 +18,7 @@
 #
 #	Description:
 
-INCLUDES	= $(I2UTILINCS)
+AM_CPPFLAGS	= $(I2UTILINCS)
 
 bin_PROGRAMS		= aespasswd
 aespasswd_SOURCES	= aespasswd.c

--- a/config/Make-rules
+++ b/config/Make-rules
@@ -25,4 +25,4 @@
 #	Files:
 #
 #	Options:
-INCLUDES	=	-I$(top_builddir) -I$(top_srcdir)
+AM_CPPFLAGS	=	-I$(top_builddir) -I$(top_srcdir)

--- a/config/c-attribute.m4
+++ b/config/c-attribute.m4
@@ -9,7 +9,7 @@ dnl
 AC_DEFUN([I2_C___ATTRIBUTE__], [
 AC_MSG_CHECKING(for __attribute__)
 AC_CACHE_VAL(ac_cv___attribute__, [
-AC_COMPILE_IFELSE([
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 
 static void foo(void) __attribute__ ((noreturn));
@@ -19,7 +19,7 @@ foo(void)
 {
   exit(1);
 }
-],
+]])],
 ac_cv___attribute__=yes,
 ac_cv___attribute__=no)])
 if test "$ac_cv___attribute__" = "yes"; then

--- a/config/c-syslog-names.m4
+++ b/config/c-syslog-names.m4
@@ -9,7 +9,7 @@ dnl
 AC_DEFUN([I2_C_SYSLOG_NAMES], [
 AC_MSG_CHECKING(for syslog names)
 AC_CACHE_VAL(ac_cv_syslognames, [
-AC_COMPILE_IFELSE([
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #define	SYSLOG_NAMES
 #include <syslog.h>
@@ -30,7 +30,7 @@ foo(void)
 
   exit(0);
 }
-],
+]])],
 ac_cv_syslognames=yes,
 ac_cv_syslognames=no)])
 if test "$ac_cv_syslognames" = "yes"; then

--- a/config/c-syslog-perror.m4
+++ b/config/c-syslog-perror.m4
@@ -9,14 +9,14 @@ dnl
 AC_DEFUN([I2_C_SYSLOG_PERROR], [
 AC_MSG_CHECKING(for syslog perror availability)
 AC_CACHE_VAL(ac_cv_syslogperror, [
-AC_COMPILE_IFELSE([
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #include <syslog.h>
 
 #ifndef LOG_PERROR
 #error  "No LOG_PERROR defined"
 #endif
-],
+]])],
 ac_cv_syslogperror=yes,
 ac_cv_syslogperror=no)])
 if test "$ac_cv_syslogperror" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -32,9 +32,13 @@ VERISION="1.5"
 
 AC_INIT(I2util, 1.5, owamp-bugs@internet2.edu)
 AC_CONFIG_AUX_DIR(config)
-AM_INIT_AUTOMAKE(I2util, 1.5, [no-define])
+AC_CONFIG_MACRO_DIR(config)
+AM_INIT_AUTOMAKE([no-define])
 AC_CONFIG_SRCDIR(I2util/ErrLog.c)
 AM_CONFIG_HEADER(I2util/config.h)
+
+# catch unexpanded macros
+m4_pattern_forbid([^I2_])
 
 # Insert local symbols
 I2UTILINCS='-I${top_srcdir}'
@@ -57,14 +61,12 @@ AC_PROG_RANLIB
 AC_CANONICAL_HOST
 AC_DEFINE(_GNU_SOURCE, 1, "Use glibc features.")
 AC_DEFINE(_LARGEFILE_SOURCE, 1, "Use largefile api.")
-AM_CONDITIONAL(I2THREADS_ENABLE, 0)
+AM_CONDITIONAL(I2THREADS_ENABLE, false)
 
-case $host in
-	*-*-solaris*)
-	AC_DEFINE(__EXTENSIONS__, 1, "get decl for sockaddr_storage on Solaris")
-	AC_DEFINE(_XOPEN_SOURCE, 500, "get decl for msg_control on Solaris")
-	;;
-esac
+AS_CASE($host,
+	*-*-solaris*,[dnl
+	AC_DEFINE(__EXTENSIONS__, 1, "get decl for sockaddr_storage on Solaris")dnl
+	AC_DEFINE(_XOPEN_SOURCE, 500, "get decl for msg_control on Solaris")])
 
 # Checks for libraries.
 AC_SEARCH_LIBS(getaddrinfo, [socket nsl])
@@ -97,10 +99,9 @@ AC_CHECK_FUNCS([memset strdup strerror strtol strtoul socket getaddrinfo])
 # Check for MAN2HTML. The manpages will be compiled to html files if it's
 # found.
 AC_CHECK_PROGS([MAN2HTML], [man2html])
-if test -n "${MAN2HTML}"; then
-    AC_DEFINE(MAN2HTML, 1, [MAN2HTML man-page converter])
-    do_man2html=true
-fi
+AS_IF([test -n "${MAN2HTML}"],
+    [AC_DEFINE(MAN2HTML, 1, [MAN2HTML man-page converter])dnl
+    do_man2html=true])
 AM_CONDITIONAL([HAVE_MAN2HTML], test x$do_man2html = xtrue)
 
 AC_SUBST(ac_aux_dir)

--- a/pfstore/Makefile.am
+++ b/pfstore/Makefile.am
@@ -18,7 +18,7 @@
 #
 #	Description:
 
-INCLUDES	= $(I2UTILINCS)
+AM_CPPFLAGS	= $(I2UTILINCS)
 
 bin_PROGRAMS		= pfstore
 pfstore_SOURCES	= pfstore.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -18,7 +18,7 @@
 #
 #	Description:
 
-INCLUDES	= $(I2UTILINCS)
+AM_CPPFLAGS	= $(I2UTILINCS)
 
 TESTS			= sha1test hmac-sha1test pbkdf2test
 check_PROGRAMS		= $(TESTS)


### PR DESCRIPTION
Updated Makefile.am, configure.ac and m4 macros for modern autoconf,
converting obsolete macros to their replacements.  Eliminates
many warnings, and adds support for autoreconf.
