### PR TITLE
Issue #8: Define SYSLOG_NAMES for only one source file.

### DIFF
--- a/I2util/ErrLogSyslog.c
+++ b/I2util/ErrLogSyslog.c
@@ -32,15 +32,18 @@
  *      License located at  http://www.opensource.org/licenses/bsd-license.php/
  *
  */
+#include <I2util/config.h>
+#ifdef HAVE_SYSLOG_NAMES
+/* utilP.h indirectly includes syslog.h, define SYSLOG_NAMES before */
+#define SYSLOG_NAMES
+#endif
+
 #include <I2util/utilP.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#ifdef  HAVE_SYSLOG_NAMES
-#define SYSLOG_NAMES
-#endif
 #include <syslog.h>
 
 /*


### PR DESCRIPTION
I2util/utilP.h includes syslog.h, so SYSLOG_NAMES needs to be
defined before it's included.  Since some ports define globals
when SYSLOG_NAMES is defined (eg darwin), only define for a
single source file (here ErrLogSyslog.c)
